### PR TITLE
Delete bundler require and dependency as it is no longer used

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,5 @@ source "http://gemcutter.org"
 group :test do
   gem 'rspec', "=1.3.0"
   gem 'rake'
-  gem 'bundler'
   gem 'rcov'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,6 @@ require 'rubygems/specification'
 require 'date'
 require "spec/rake/spectask"
 require 'rake/rdoctask'
-require 'bundler'
 
 PROJECT_NAME = "randexp"
 GEM = "randexp"


### PR DESCRIPTION
Since https://github.com/benburkert/randexp/commit/d5aef3654821d55ef19d7dc87f7e070e973af078 bundler is no longer used by randexp.
